### PR TITLE
Update expo installation command to npx expo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ After installing the onseignal-expo-plugin, install now the react-native-onesign
 yarn add react-native-onesignal
 ```
 
-If you frogot to run the following command after you have built your project, you can fix this by running `expo prebuild --clean`. This should delete android and ios and do a clean native build, then run the `yarn add react-native-onesignal`.
+If you forgot to run the following command after you have built your project, you can fix this by running `npx expo prebuild --clean`. This should delete android and ios and do a clean native build, then run the `yarn add react-native-onesignal`.
 
 ## Configuration in app.json / app.config.js
 ### Plugin
@@ -108,13 +108,13 @@ OneSignal.setAppId("YOUR-ONESIGNAL-APP-ID");
 
 ## Run
 ```sh
-$ expo prebuild
+$ npx expo prebuild
 
 # Build your native iOS project
-$ expo run:ios
+$ npx expo run:ios
 
 # Build your native Android project
-$ expo run:android
+$ npx expo run:android
 ```
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This plugin is an [Expo Config Plugin](https://docs.expo.dev/guides/config-plugi
 ## Install
 
 ```sh
-expo install onesignal-expo-plugin
+npx expo install onesignal-expo-plugin
 ```
 
 **Note:**


### PR DESCRIPTION
Hi 👋 

As per the latest Expo SDK (46 and above), we released a new local CLI and recommend to use `npx expo` to perform tasks such as installing a config plugin, a library, starting the development server, and so on. [For more info, please see Expo CLI docs here](https://docs.expo.dev/workflow/expo-cli/).

This PR updates the command to reflect the current state of things. Also, fixed a typo.